### PR TITLE
canonize ckeys in query api

### DIFF
--- a/code/datums/api_handler.dm
+++ b/code/datums/api_handler.dm
@@ -55,7 +55,7 @@ var/global/datum/apiHandler/apiHandler
 			return
 
 		if ("ckey" in query)
-			query["ckey"] == ckey(query["ckey"]) // Sorry future devs - qwerty
+			query["ckey"] = ckey(query["ckey"]) // Sorry future devs - qwerty
 
 		var/req = "[config.cloverfield_api_endpoint]/[route]/?[query ? "[list2params(query)]&" : ""]" //Necessary
 		req += "[forceResponse ? "bypass=1&" : ""]" //Force a response RIGHT NOW y/n


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Canonizes ckeys before they get to cloverfield

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Made adhara not cause 62 runtimes

## Changelog

```
(u)qwertyquerty:
(+)Canonizes ckeys before they get to cloverfield
```
