### PR TITLE
Mirror bans don't trigger evasion detection.

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -89,7 +89,7 @@ var/global/list/playersSeen = list()
 
 	//Are any of the details...different? This is to catch out ban evading jerks who change their ckey but forget to mask their IP or whatever
 	var/timeAdded = 0
-	if (row["ckey"] != ckey || row["ip"] != ip || row["compID"] != compID) //Insert a new ban for this JERK
+	if (row["server"] != "MIRROR" && (row["ckey"] != ckey || row["ip"] != ip || row["compID"] != compID)) //Insert a new ban for this JERK
 		var/newChain = 0
 		if (text2num(row["previous"]) > 0) //if we matched a previous auto-added ban
 			if (text2num(row["chain"]) > 0)


### PR DESCRIPTION
They're ephemeral and don't *really* exist.
