### PR TITLE
Removes flock game mode

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -31,7 +31,7 @@ datum/preferences
 	var/be_gangleader = 0
 	var/be_wraith = 0
 	var/be_blob = 0
-	var/be_flock = 0
+//	var/be_flock = 0
 	var/be_misc = 0
 
 	var/be_random_name = 0
@@ -1178,7 +1178,7 @@ $(function() {
 			src.be_gangleader = 0
 			src.be_wraith = 0
 			src.be_blob = 0
-			src.be_flock = 0
+//			src.be_flock = 0
 		else
 
 			HTML += {"
@@ -1193,7 +1193,7 @@ $(function() {
 			<a href="byond://?src=\ref[src];preferences=1;b_vampire=1" class="[src.be_vampire ? "yup" : "nope"]">[crap_checkbox(src.be_vampire)] Vampire</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_wraith=1" class="[src.be_wraith ? "yup" : "nope"]">[crap_checkbox(src.be_wraith)] Wraith</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_blob=1" class="[src.be_blob ? "yup" : "nope"]">[crap_checkbox(src.be_blob)] Blob</a>
-			<a href="byond://?src=\ref[src];preferences=1;b_flock=1" class="[src.be_flock ? "yup" : "nope"]">[crap_checkbox(src.be_flock)] Flockmind</a>
+//			<a href="byond://?src=\ref[src];preferences=1;b_flock=1" class="[src.be_flock ? "yup" : "nope"]">[crap_checkbox(src.be_flock)] Flockmind</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_misc=1" class="[src.be_misc ? "yup" : "nope"]">[crap_checkbox(src.be_misc)] Other Foes</a>
 		"}
 
@@ -1794,10 +1794,10 @@ $(function() {
 			src.be_blob = !( src.be_blob)
 			src.SetChoices(user)
 			return
-		if (link_tags["b_flock"])
-			src.be_flock = !( src.be_flock)
-			src.SetChoices(user)
-			return
+//		if (link_tags["b_flock"])
+//			src.be_flock = !( src.be_flock)
+//			src.SetChoices(user)
+//			return
 
 		if (link_tags["b_misc"])
 			src.be_misc = !src.be_misc

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -780,7 +780,7 @@ var/global/noir = 0
 							<A href='?src=\ref[src];action=[cmd];type=spy_theft'>Spy Theft</A><br>
 							<b>Other Modes</b><br>
 							<A href='?src=\ref[src];action=[cmd];type=extended'>Extended</A><br>
-							<A href='?src=\ref[src];action=[cmd];type=flock'>Flock(probably wont work. Press at own risk)</A><br>
+//							<A href='?src=\ref[src];action=[cmd];type=flock'>Flock(probably wont work. Press at own risk)</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=disaster'>Disaster (Beta)</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=spy'>Spy</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=revolution'>Revolution</A><br>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Its hella unstable.
its a diceroll if the round will end when the shuttle lands.
Flock isnt finished in any sense of the word.
if an admin wants a flockmind in round they can just (optionally)set it to extended then elect a ghost instead of using this godforsaken gamemode

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We all know just how trigger happy admins can be with buttons. Removing this until flock is finished(or the gamemode doesnt just straight up halt the server) is a good idea.


spoiler alert i didnt test these changes but they **should** work