### PR TITLE
Rework all the goon discord stuff to use a TGS bot

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -104,6 +104,7 @@
 #include "macros\vehicles.dm"
 #include "address.dm"
 #include "ass_jam.dm"
+#include "chat.dm"
 #include "color.dm"
 #include "copy.dm"
 #include "datum.dm"

--- a/_std/chat.dm
+++ b/_std/chat.dm
@@ -26,3 +26,44 @@
 				if(C.custom_tag == channel_tag)
 					channels += C
 			world.TgsChatBroadcast(message, channels)
+
+
+/* CHAT COMMANDS */
+/datum/tgs_chat_command/ping
+	name = "ping"
+	help_text = "Check that the server's alive"
+
+/datum/tgs_chat_command/ping/Run(datum/tgs_chat_user/sender, params)
+	return "Pong, [sender.friendly_name]!"
+
+/datum/tgs_chat_command/check
+	name = "check"
+	help_text = "Get information about the current round"
+
+// Oh god I can feel the jank
+/datum/tgs_chat_command/check/proc/pad_time(num)
+	var/str = "[num]"
+	if(length(str) < 2)
+		// single digits
+		str = "0[str]"
+	return str
+
+/datum/tgs_chat_command/check/Run(datum/tgs_chat_user/sender, params)
+	// Yoink
+	var/elapsed
+	if (current_state < GAME_STATE_FINISHED)
+		if (current_state <= GAME_STATE_PREGAME) elapsed = "STARTING"
+		else if (current_state > GAME_STATE_PREGAME)
+			// Number of elapsed seconds
+			var/temp = round(ticker.round_elapsed_ticks / 10)
+			// Hours
+			var/hours = round(temp / 3600)
+			temp -= hours * 3600
+			// Minutes
+			var/minutes = round(temp / 60)
+			temp -= minutes * 60
+			// Seconds
+			var/seconds = temp
+			elapsed = "[pad_time(hours)]:[pad_time(minutes)]:[pad_time(seconds)] elapsed"
+	else if (current_state == GAME_STATE_FINISHED) elapsed = "ENDING"
+	return "[config.server_name] ([station_name]) [clients.len] players Map: [getMapNameFromID(map_setting)] Mode: [(ticker?.hide_mode) ? "secret" : master_mode]; [elapsed] -- <byond://[world.internet_address]:[world.port]>"

--- a/_std/chat.dm
+++ b/_std/chat.dm
@@ -1,0 +1,28 @@
+/**
+ * Allows sending a message to a specified chat, given a custom tag.
+ *
+ * @param message The text for the message we're sending
+ * @param channel_tag The tag (set in the TGS control panel) to send the message to. This is optional, and sends to all channels if not specified. Setting to -1 will send to admins only (yes this is jank)
+ * @return nothing
+ */
+/proc/discord_send(message, channel_tag = null)
+	if(!world.TgsAvailable())
+		return
+
+	// send everywhere
+	if(channel_tag == null)
+		world.TgsTargetedChatBroadcast(message, FALSE)
+	else if(channel_tag == -1)
+		world.TgsTargetedChatBroadcast(message, TRUE)
+	else
+		var/datum/tgs_version/V = world.TgsApiVersion()
+		if(V.suite < 4)
+			// Running TGS 3
+			world.TgsTargetedChatBroadcast(message, FALSE)
+		else
+			var/list/datum/tgs_chat_channel/channels = list()
+			// API version 4 or later
+			for(var/datum/tgs_chat_channel/C in world.TgsChatChannelInfo())
+				if(C.custom_tag == channel_tag)
+					channels += C
+			world.TgsChatBroadcast(message, channels)

--- a/_std/chat.dm
+++ b/_std/chat.dm
@@ -67,3 +67,30 @@
 			elapsed = "[pad_time(hours)]:[pad_time(minutes)]:[pad_time(seconds)] elapsed"
 	else if (current_state == GAME_STATE_FINISHED) elapsed = "ENDING"
 	return "[config.server_name] ([station_name]) [clients.len] players Map: [getMapNameFromID(map_setting)] Mode: [(ticker?.hide_mode) ? "secret" : master_mode]; [elapsed] -- <byond://[world.internet_address]:[world.port]>"
+
+/datum/tgs_chat_command/reboot
+	name = "reboot"
+	help_text = "<normal|hard|tgs>"
+	admin_only_goon_sucks = TRUE
+
+/datum/tgs_chat_command/reboot/Run(datum/tgs_chat_user/sender, params)
+	if(!params)
+		return "Insufficient parameters"
+	var/list/all_params = splittext(params, " ")
+	if(all_params.len != 1 && all_params.len != 2)
+		return "Invalid amount of parameters"
+	var/delay = (all_params.len == 2) ? text2num(all_params[2]) : 1
+	var/mode = all_params[1]
+	var/init_by = "Initiated by an Admin remotely through the TGS Relay."
+	switch(mode)
+		if("normal")
+			out(world, "<span class='bold notice'>Initiating world restart, requested remotely through the TGS relay.</span>")
+			Reboot_server()
+		if("hard")
+			out(world, "<span class='bold notice'>World reboot - [init_by]</span>")
+			world.Reboot()
+		if("tgs")
+			out(world, "<span class='bold notice'>Server restart - [init_by]</span>")
+			world.TgsEndProcess()
+		else
+			return "Invalid reboot mode"

--- a/_std/chat.dm
+++ b/_std/chat.dm
@@ -77,9 +77,8 @@
 	if(!params)
 		return "Insufficient parameters"
 	var/list/all_params = splittext(params, " ")
-	if(all_params.len != 1 && all_params.len != 2)
+	if(length(all_params) != 1)
 		return "Invalid amount of parameters"
-	var/delay = (all_params.len == 2) ? text2num(all_params[2]) : 1
 	var/mode = all_params[1]
 	var/init_by = "Initiated by an Admin remotely through the TGS Relay."
 	switch(mode)

--- a/_std/chat.dm
+++ b/_std/chat.dm
@@ -9,6 +9,14 @@
 	if(!world.TgsAvailable())
 		return
 
+	// Sanitize
+	var/static/list/filtered_chars = list(
+		"@" = "\[at]",
+		"#" = "\[hash]"
+	)
+	for(var/char in filtered_chars)
+		message = replacetext(message, char, filtered_chars[char])
+
 	// send everywhere
 	if(channel_tag == null)
 		world.TgsTargetedChatBroadcast(message, FALSE)

--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -1093,13 +1093,7 @@ proc/Create_Tommyname()
 		logTheThing("admin", M, null, message)
 		logTheThing("diary", M, null, message, "admin")
 
-		if(external_alert)
-			//IRCbot alert, for fun
-			var/ircmsg[] = new()
-			ircmsg["key"] =  M.key
-			ircmsg["name"] = stripTextMacros(M.real_name)
-			ircmsg["msg"] = "[message] and got themselves got by the anti-cheat cluwne."
-			ircbot.export("admin", ircmsg)
+		discord_send("[stripTextMacros(M.real_name)] ([M.key]) [message] and got themselves got by the anti-cheat cluwne.", -1)
 
 		M.cluwnegib(15, 1)
 

--- a/code/WorkInProgress/WiresStuff.dm
+++ b/code/WorkInProgress/WiresStuff.dm
@@ -239,7 +239,4 @@ var/global/deathConfettiActive = 0
 	logTheThing("diary", src, null, logMessage, "admin")
 	message_admins("[key_name(src)] [logMessage]")
 
-	var/ircmsg[] = new()
-	ircmsg["key"] = src.key
-	ircmsg["msg"] = logMessage
-	ircbot.export("admin", ircmsg)
+	discord_send("[src.key] [logMessage]", -1)

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -398,9 +398,7 @@
 			var/obj/item/paper/P = I
 			if(P.info && !taken_suggestion)
 				message_admins("[user] ([user?.ckey]) has made a suggestion in [src]:<br>[P.name]<br><br>[copytext(P.info,1,MAX_MESSAGE_LEN)]")
-				var/ircmsg[] = new()
-				ircmsg["msg"] = "[user] ([user?.ckey]) has made a suggestion in [src]:\n**[P.name]**\n[strip_html_tags(P.info)]"
-				ircbot.export("admin", ircmsg)
+				discord_send("[user] ([user?.ckey]) has made a suggestion in [src]:\n**[P.name]**\n[strip_html_tags(P.info)]", -1)
 				taken_suggestion = 1
 			user.u_equip(P)
 			qdel(P)

--- a/code/client.dm
+++ b/code/client.dm
@@ -501,7 +501,7 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 		if (winget(src, null, "hwmode") != "true")
 			alert(src, "Hardware rendering is disabled.  This may cause errors displaying lighting, manifesting as BIG WHITE SQUARES.\nPlease enable hardware rendering from the byond preferences menu.","Potential Rendering Issue")
 
-		ircbot.event("login", src.key)
+		discord_send("[src.key] logged into [config.server_name]", "event")
 #if defined(RP_MODE) && !defined(IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME)
 		src.verbs += /client/proc/cmd_rp_rules
 		if (istype(src.mob, /mob/new_player))
@@ -964,13 +964,10 @@ var/global/curr_day = null
 			logTheThing("admin_help", src, null, "<b>PM'd [target]</b>: [t]")
 			logTheThing("diary", src, null, "PM'd [target]: [t]", "ahelp")
 
-			var/ircmsg[] = new()
-			ircmsg["key"] = src.mob && src ? src.key : ""
-			ircmsg["name"] = stripTextMacros(src.mob.real_name)
-			ircmsg["key2"] = target
-			ircmsg["name2"] = "Discord"
-			ircmsg["msg"] = html_decode(t)
-			ircbot.export("pm", ircmsg)
+			var/key = src.mob && src ? src.key : ""
+			var/realname = stripTextMacros(src.mob.real_name)
+
+			discord_send("Admin-PM from [realname] ([key]) to [target] (Discord): [html_decode(t)]", -1)
 
 			//we don't use message_admins here because the sender/receiver might get it too
 			for (var/client/C)
@@ -998,13 +995,10 @@ var/global/curr_day = null
 			logTheThing("mentor_help", src, null, "<b>Mentor PM'd [target]</b>: [t]")
 			logTheThing("diary", src, null, "Mentor PM'd [target]: [t]", "admin")
 
-			var/ircmsg[] = new()
-			ircmsg["key"] = src.mob && src ? src.key : ""
-			ircmsg["name"] = stripTextMacros(src.mob.real_name)
-			ircmsg["key2"] = target
-			ircmsg["name2"] = "Discord"
-			ircmsg["msg"] = html_decode(t)
-			ircbot.export("mentorpm", ircmsg)
+			var/key = src.mob && src ? src.key : ""
+			var/name = stripTextMacros(src.mob.real_name)
+
+			discord_send("MENTOR PM: From [name] ([key]) To [target] (Discord): [html_decode(t)]", -1)
 
 			//we don't use message_admins here because the sender/receiver might get it too
 			var/mentormsg = "<span class='mhelp'><b>MENTOR PM: [key_name(src.mob,0,0,1)] <i class='icon-arrow-right'></i> [target] (Discord)</b>: <span class='message'>[t]</span></span>"
@@ -1048,13 +1042,12 @@ var/global/curr_day = null
 				logTheThing("mentor_help", src.mob, M, "Mentor PM'd [constructTarget(M,"mentor_help")]: [t]")
 				logTheThing("diary", src.mob, M, "Mentor PM'd [constructTarget(M,"diary")]: [t]", "admin")
 
-				var/ircmsg[] = new()
-				ircmsg["key"] = src.mob && src ? src.key : ""
-				ircmsg["name"] = stripTextMacros(src.mob.real_name)
-				ircmsg["key2"] = (M != null && M.client != null && M.client.key != null) ? M.client.key : ""
-				ircmsg["name2"] = (M != null && M.real_name != null) ? stripTextMacros(M.real_name) : ""
-				ircmsg["msg"] = html_decode(t)
-				ircbot.export("mentorpm", ircmsg)
+				var/key = src.mob && src ? src.key : ""
+				var/name = stripTextMacros(src.mob.real_name)
+				var/key2 = (M != null && M.client != null && M.client.key != null) ? M.client.key : ""
+				var/name2 = (M != null && M.real_name != null) ? stripTextMacros(M.real_name) : ""
+
+				discord_send("Mentor-PM from [name] ([key]) to [name2] ([key2]): [html_decode(t)]", -1)
 
 				var/mentormsg = "<span class='mhelp'><b>MENTOR PM: [key_name(src.mob,0,0,1)] <i class='icon-arrow-right'></i> [key_name(M,0,0,1)]</b>: <span class='message'>[t]</span></span>"
 				for (var/client/C)

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -173,12 +173,7 @@ var/global
 						message_admins("[src.owner] just attempted to crash the server using at least 5 '\['s in a row.")
 						logTheThing("admin", src.owner, null, "just attempted to crash the server using at least 5 '\['s in a row.", "admin")
 
-						//Irc message too
-						var/ircmsg[] = new()
-						ircmsg["key"] = owner.key
-						ircmsg["name"] = stripTextMacros(owner.mob.name)
-						ircmsg["msg"] = "just attempted to crash the server using at least 5 '\['s in a row."
-						ircbot.export("admin", ircmsg)
+						discord_send("[stripTextMacros(owner.mob.name)] ([owner.key]) just attempted to crash the server using at least 5 '\['s in a row.", -1)
 					return
 
 				var/list/connData = json_decode(cookie)
@@ -202,11 +197,7 @@ var/global
 
 						//Irc message too
 						if(owner)
-							var/ircmsg[] = new()
-							ircmsg["key"] = owner.key
-							ircmsg["name"] = stripTextMacros(owner.mob.name)
-							ircmsg["msg"] = "has a cookie from banned account [found["ckey"]](IP: [found["ip"]], CompID: [found["compID"]])"
-							ircbot.export("admin", ircmsg)
+							discord_send("[stripTextMacros(owner.mob.name)] ([owner.key]) has a cookie from banned account [found["ckey"]](IP: [found["ip"]], CompID: [found["compID"]])", -1)
 
 						var/banData[] = new()
 						banData["ckey"] = src.owner.ckey

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -221,7 +221,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	round_time_check = world.timeofday
 
 	SPAWN_DBG(0)
-		ircbot.event("roundstart")
+		discord_send("Round has begun on [config.server_name].", "status")
 		mode.post_setup()
 
 		event_wormhole_buildturflist()
@@ -448,11 +448,9 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 					message_admins("<span class='internal'>Server would have restarted now, but the restart has been delayed[game_end_delayer ? " by [game_end_delayer]" : null]. Remove the delay for an immediate restart.</span>")
 					game_end_delayed = 2
-					var/ircmsg[] = new()
-					ircmsg["msg"] = "Server would have restarted now, but the restart has been delayed[game_end_delayer ? " by [game_end_delayer]" : null]."
-					ircbot.export("admin", ircmsg)
+					discord_send("Server would have restarted now, but the restart has been delayed[game_end_delayer ? " by [game_end_delayer]" : null].", -1)
 				else
-					ircbot.event("roundend")
+					discord_send("Round just ended on [config.server_name].", "status")
 					//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] REBOOTING THE SERVER!!!!!!!!!!!!!!!!!")
 					Reboot_server()
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -221,7 +221,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	round_time_check = world.timeofday
 
 	SPAWN_DBG(0)
-		discord_send("Round has begun on [config.server_name].", "status")
+		discord_send("Round has begun on [config.server_name].", -1)
 		mode.post_setup()
 
 		event_wormhole_buildturflist()
@@ -450,7 +450,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 					game_end_delayed = 2
 					discord_send("Server would have restarted now, but the restart has been delayed[game_end_delayer ? " by [game_end_delayer]" : null].", -1)
 				else
-					discord_send("Round just ended on [config.server_name].", "status")
+					discord_send("Round just ended on [config.server_name].", -1)
 					//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] REBOOTING THE SERVER!!!!!!!!!!!!!!!!!")
 					Reboot_server()
 

--- a/code/datums/ircbot.dm
+++ b/code/datums/ircbot.dm
@@ -179,6 +179,7 @@ var/global/datum/ircbot/ircbot = new /datum/ircbot()
 
 	if (!discordCode || !src.ckey) return 0
 
+	// Note from Terra: this one is actually basically an API call. I can't replace it easily. Will deal with another time.
 	var/ircmsg[] = new()
 	ircmsg["key"] = src.key
 	ircmsg["ckey"] = src.ckey

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4285,7 +4285,7 @@ var/global/noir = 0
 		logTheThing("admin", usr, null, "removed the restart delay and triggered an immediate restart.")
 		logTheThing("diary", usr, null, "removed the restart delay and triggered an immediate restart.", "admin")
 		message_admins("<span class='internal'>[usr.key] removed the restart delay and triggered an immediate restart.</span>")
-		discord_send("Round just ended on [config.server_name].", "status")
+		discord_send("Round just ended on [config.server_name].", -1)
 		Reboot_server()
 
 	else if (game_end_delayed == 0)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -370,11 +370,9 @@ var/global/noir = 0
 				logTheThing("diary", usr, null, "[emergency_shuttle.disabled ? "dis" : "en"]abled calling the Emergency Shuttle", "admin")
 				message_admins("<span class='internal'>[key_name(usr)] [emergency_shuttle.disabled ? "dis" : "en"]abled calling the Emergency Shuttle</span>")
 				// someone forgetting about leaving shuttle calling disabled would be bad so let's inform the Admin Crew if it happens, just in case
-				var/ircmsg[] = new()
-				ircmsg["key"] = src.owner:key
-				ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-				ircmsg["msg"] = "Has [emergency_shuttle.disabled ? "dis" : "en"]abled calling the Emergency Shuttle"
-				ircbot.export("admin", ircmsg)
+				var/key = usr.client.key
+				var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+				discord_send("[name] ([key])(Has [emergency_shuttle.disabled ? "dis" : "en"]abled calling the Emergency Shuttle", -1)
 			else
 				alert("You need to be at least a Primary Administrator to enable/disable shuttle calling.")
 
@@ -422,11 +420,9 @@ var/global/noir = 0
 							logTheThing("diary", usr, null, "deleted note [noteId] belonging to [player].", "admin")
 							message_admins("<span class='internal'>[key_name(usr)] deleted note [noteId] belonging to <A href='?src=%admin_ref%;action=notes&target=[player]'>[player]</A>.</span>")
 
-							var/ircmsg[] = new()
-							ircmsg["key"] = src.owner:key
-							ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-							ircmsg["msg"] = "Deleted note [noteId] belonging to [player]"
-							ircbot.export("admin", ircmsg)
+							var/key =  src.owner:key
+							var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+							discord_send("[name] ([key]) Deleted note [noteId] belonging to [player]", -1)
 
 				if("add")
 					if(src.level < LEVEL_SA)
@@ -444,11 +440,9 @@ var/global/noir = 0
 					logTheThing("diary", usr, null, "added a note for [player]: [the_note]", "admin")
 					message_admins("<span class='internal'>[key_name(usr)] added a note for <A href='?src=%admin_ref%;action=notes&target=[player]'>[player]</A>: [the_note]</span>")
 
-					var/ircmsg[] = new()
-					ircmsg["key"] = src.owner:key
-					ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-					ircmsg["msg"] = "Added a note for [player]: [the_note]"
-					ircbot.export("admin", ircmsg)
+					var/key = src.owner:key
+					var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+					discord_send("[name] ([key]) Added a note for [player]: [the_note]", -1)
 
 		if("viewcompids")
 			var/player = href_list["targetckey"]
@@ -2112,11 +2106,9 @@ var/global/noir = 0
 					logTheThing("diary", usr, null, "has removed [C]'s adminship", "admin")
 					message_admins("[key_name(usr)] has removed [C]'s adminship")
 
-					var/ircmsg[] = new()
-					ircmsg["key"] = usr.client.key
-					ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-					ircmsg["msg"] = "has removed [C]'s adminship"
-					ircbot.export("admin", ircmsg)
+					var/key = usr.client.key
+					var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+					discord_send("[name] ([key]) has removed [C]'s adminship", -1)
 
 					admins.Remove(C.ckey)
 					onlineAdmins.Remove(C)
@@ -2127,11 +2119,9 @@ var/global/noir = 0
 					logTheThing("diary", usr, null, "has made [C] a [rank]", "admin")
 					message_admins("[key_name(usr)] has made [C] a [rank]")
 
-					var/ircmsg[] = new()
-					ircmsg["key"] = usr.client.key
-					ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-					ircmsg["msg"] = "has made [C] a [rank]"
-					ircbot.export("admin", ircmsg)
+					var/key = usr.client.key
+					var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+					discord_send("[name] ([key]) has made [C] a [rank]", -1)
 
 					admins[C.ckey] = rank
 					onlineAdmins.Add(C)
@@ -4227,11 +4217,9 @@ var/global/noir = 0
 		logTheThing("admin", usr, null, "initiated a reboot.")
 		logTheThing("diary", usr, null, "initiated a reboot.", "admin")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = usr.client.key
-		ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-		ircmsg["msg"] = "manually restarted the server."
-		ircbot.export("admin", ircmsg)
+		var/key = usr.client.key
+		var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+		discord_send("[name] ([key]) manually restarted the server.", -1)
 
 		round_end_data(2) //Wire: Export round end packet (manual restart)
 
@@ -4297,7 +4285,7 @@ var/global/noir = 0
 		logTheThing("admin", usr, null, "removed the restart delay and triggered an immediate restart.")
 		logTheThing("diary", usr, null, "removed the restart delay and triggered an immediate restart.", "admin")
 		message_admins("<span class='internal'>[usr.key] removed the restart delay and triggered an immediate restart.</span>")
-		ircbot.event("roundend")
+		discord_send("Round just ended on [config.server_name].", "status")
 		Reboot_server()
 
 	else if (game_end_delayed == 0)
@@ -4307,11 +4295,9 @@ var/global/noir = 0
 		logTheThing("diary", usr, null, "delayed the server restart.", "admin")
 		message_admins("<span class='internal'>[usr.key] delayed the server restart.</span>")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = (usr?.client) ? usr.client.key : "NULL"
-		ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-		ircmsg["msg"] = "has delayed the server restart."
-		ircbot.export("admin", ircmsg)
+		var/key = (usr?.client) ? usr.client.key : "NULL"
+		var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+		discord_send("[name] ([key]) has delayed the server restart.", "event")
 
 	else if (game_end_delayed == 1)
 		game_end_delayed = 0
@@ -4320,11 +4306,9 @@ var/global/noir = 0
 		logTheThing("diary", usr, null, "removed the restart delay.", "admin")
 		message_admins("<span class='internal'>[usr.key] removed the restart delay.</span>")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = (usr?.client) ? usr.client.key : "NULL"
-		ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-		ircmsg["msg"] = "has removed the server restart delay."
-		ircbot.export("admin", ircmsg)
+		var/key = (usr?.client) ? usr.client.key : "NULL"
+		var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+		discord_send("[name] ([key]) has removed the server restart delay.", "event")
 
 /mob/proc/revive()
 	if(ishuman(src))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -746,7 +746,7 @@ var/list/special_pa_observing_verbs = list(
 	if (src.owner:stealth)
 		var/key = src.owner:key
 		var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-		discord_send("[name] ([key]) Has enabled stealth mode as ([src.owner:fakekey])")
+		discord_send("[name] ([key]) Has enabled stealth mode as ([src.owner:fakekey])", -1)
 
 /client/proc/alt_key()
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -744,11 +744,9 @@ var/list/special_pa_observing_verbs = list(
 	message_admins("[key_name(src.owner)] has turned stealth mode [src.owner:stealth ? "ON using key \"[src.owner:fakekey]\"" : "OFF"]")
 
 	if (src.owner:stealth)
-		var/ircmsg[] = new()
-		ircmsg["key"] = src.owner:key
-		ircmsg["name"] = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
-		ircmsg["msg"] = "Has enabled stealth mode as ([src.owner:fakekey])"
-		ircbot.export("admin", ircmsg)
+		var/key = src.owner:key
+		var/name = (usr?.real_name) ? stripTextMacros(usr.real_name) : "NULL"
+		discord_send("[name] ([key]) Has enabled stealth mode as ([src.owner:fakekey])")
 
 /client/proc/alt_key()
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -56,17 +56,10 @@
 
 	if (!first_adminhelp_happened && config.weblog_viewer_url)
 		first_adminhelp_happened = 1
-		var/ircmsg[] = new()
-		ircmsg["key"] = "Loggo"
-		ircmsg["name"] = "First Adminhelp Notice"
-		ircmsg["msg"] = "Logs for this round can be found here: [config.weblog_viewer_url]/ss13/admin/log-get.php?id=[config.server_id]&date=[roundLog_date]"
-		ircbot.export("help", ircmsg)
+		// Terra's Note: old link (waka's site): https://mini.xkeeper.net/ss13/admin/log-get.php?id=[config.server_id]&date=[roundLog_date]
+		discord_send("Admin-Help From: First Adminhelp Notice (Loggo): Logs for this round can be found here: [config.weblog_viewer_url]/ss13/admin/log-get.php?id=[config.server_id]&date=[roundLog_date]", -1)
 
-	var/ircmsg[] = new()
-	ircmsg["key"] = client.key
-	ircmsg["name"] = stripTextMacros(client.mob.real_name)
-	ircmsg["msg"] = html_decode(msg)
-	ircbot.export("help", ircmsg)
+	discord_send("Admin-Help From: [stripTextMacros(client.mob.real_name)] ([client.key]): [html_decode(msg)]", -1)
 
 /mob/verb/mentorhelp()
 	set category = "Commands"
@@ -136,11 +129,9 @@
 	game_stats.Increment("mentorhelps")
 #endif
 	var/dead = isdead(client.mob) ? "Dead" : ""
-	var/ircmsg[] = new()
-	ircmsg["key"] = client.key
-	ircmsg["name"] = client.mob.job ? "[stripTextMacros(client.mob.real_name)] \[[dead] [client.mob.job]]" : (dead ? "[stripTextMacros(client.mob.real_name)] \[[dead]\]" : stripTextMacros(client.mob.real_name))
-	ircmsg["msg"] = html_decode(msg)
-	ircbot.export("mentorhelp", ircmsg)
+	var/key = client.key
+	var/name = client.mob.job ? "[stripTextMacros(client.mob.real_name)] \[[dead] [client.mob.job]]" : (dead ? "[stripTextMacros(client.mob.real_name)] \[[dead]\]" : stripTextMacros(client.mob.real_name))
+	discord_send("MENTORHELP: [name] ([key]): [html_decode(msg)]", -1)
 
 /mob/verb/pray(msg as text)
 	set category = "Commands"
@@ -273,13 +264,11 @@
 		logTheThing("admin_help", user, M, "<b>PM'd [constructTarget(M,"admin_help")]</b>: [t]")
 		logTheThing("diary", user, M, "PM'd [constructTarget(M,"diary")]: [t]", "ahelp")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = user?.client ? user.client.key : ""
-		ircmsg["name"] = stripTextMacros(user.real_name)
-		ircmsg["key2"] = (M != null && M.client != null && M.client.key != null) ? M.client.key : ""
-		ircmsg["name2"] = (M != null && M.real_name != null) ? stripTextMacros(M.real_name) : ""
-		ircmsg["msg"] = html_decode(t)
-		ircbot.export("pm", ircmsg)
+		var/key = user?.client ? user.client.key : ""
+		var/name = stripTextMacros(user.real_name)
+		var/key2 = (M != null && M.client != null && M.client.key != null) ? M.client.key : ""
+		var/name2 = (M != null && M.real_name != null) ? stripTextMacros(M.real_name) : ""
+		discord_send("Admin PM From [name] ([key]) To [name2] ([key2]): [html_decode(t)]", -1)
 
 		//we don't use message_admins here because the sender/receiver might get it too
 		for (var/client/CC)

--- a/code/modules/admin/adminsay.dm
+++ b/code/modules/admin/adminsay.dm
@@ -20,11 +20,7 @@
 		special = "gfartadmin"
 	message_admins("[key_name(src)]: <span class=\"adminMsgWrap [special]\">[msg]</span>", 1)
 
-	var/ircmsg[] = new()
-	ircmsg["key"] = src.key
-	ircmsg["name"] = stripTextMacros(src.mob.real_name)
-	ircmsg["msg"] = html_decode(msg)
-	ircbot.export("asay", ircmsg)
+	discord_send("Asay from [stripTextMacros(src.mob.real_name)] ([src.key]): [html_decode(msg)]", -1)
 
 /client/proc/cmd_admin_forceallsay(msg as text)
 	SET_ADMIN_CAT(ADMIN_CAT_FUN)
@@ -160,4 +156,3 @@
 	logTheThing("admin", usr, null, "forced Beepsky to beep: [msg]")
 	logTheThing("diary", usr, null, "forced Beepsky to beep: [msg]", "admin")
 	message_admins("<span class='internal'>[key_name(usr)] forced Beepsky to beep: [msg]</span>")
-

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -208,12 +208,10 @@ var/global/list/playersSeen = list()
 		if (row["ckey"] && row["ckey"] != "N/A")
 			addPlayerNote(row["ckey"], row["akey"], "Banned [serverLogSnippet] by [row["akey"]], reason: [row["reason"]], duration: [(expiry == 0 ? "Permanent": "[expiry]")]")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = row["akey"]
-		ircmsg["key2"] = "[row["ckey"]] (IP: [row["ip"]], CompID: [row["compID"]])"
-		ircmsg["msg"] = row["reason"]
-		ircmsg["time"] = expiry
-		ircbot.export("ban", ircmsg)
+		var/key = row["akey"]
+		var/key2 = "[row["ckey"]] (IP: [row["ip"]], CompID: [row["compID"]])"
+		var/msg = row["reason"]
+		discord_send("Ban applied by [key] against [key2] for reason [msg] with expiry [expiry]", -1)
 
 		if (targetC)
 			if (targetC.mob)
@@ -384,11 +382,10 @@ var/global/list/playersSeen = list()
 		logTheThing("diary", adminC, target, "edited [constructTarget(target,"diary")]'s ban. Reason: [row["reason"]] Duration: [(expiry == 0 ? "Permanent": "[expiry]")] [serverLogSnippet]", "admin")
 		message_admins("<span class='internal'>[key_name(adminC)] edited [target]'s ban. Reason: [row["reason"]] Duration: [(expiry == 0 ? "Permanent": "[expiry]")] [serverLogSnippet]</span>")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = (isclient(adminC) && adminC.key ? adminC.key : adminC)
-		ircmsg["name"] = (isclient(adminC) && adminC.mob && adminC.mob.name ? stripTextMacros(adminC.mob.name) : "N/A")
-		ircmsg["msg"] = "edited [target]'s ban. Reason: [row["reason"]]. Duration: [(expiry == 0 ? "Permanent": "[expiry]")]. [serverLogSnippet]."
-		ircbot.export("admin", ircmsg)
+		var/key = (isclient(adminC) && adminC.key ? adminC.key : adminC)
+		var/name = (isclient(adminC) && adminC.mob && adminC.mob.name ? stripTextMacros(adminC.mob.name) : "N/A")
+		var/msg = "edited [target]'s ban. Reason: [row["reason"]]. Duration: [(expiry == 0 ? "Permanent": "[expiry]")]. [serverLogSnippet]."
+		discord_send("[name] ([key]) [msg]")
 
 		return 0
 
@@ -517,11 +514,10 @@ var/global/list/playersSeen = list()
 			logTheThing("diary", adminC, null, "unbanned [row["ckey"]]", "admin")
 			message_admins("<span class='internal'>[key_name(adminC)] unbanned [target]</span>")
 
-		var/ircmsg[] = new()
-		ircmsg["key"] = (isclient(adminC) && adminC.key ? adminC.key : adminC)
-		ircmsg["name"] = (expired ? "\[Expired\]" : "[isclient(adminC) && adminC.mob && adminC.mob.name ? stripTextMacros(adminC.mob.name) : "N/A"]")
-		ircmsg["msg"] = (expired ? "[row["ckey"]]'s ban removed." : "deleted [row["ckey"]]'s ban.")
-		ircbot.export("admin", ircmsg)
+		var/key = (isclient(adminC) && adminC.key ? adminC.key : adminC)
+		var/name = (expired ? "\[Expired\]" : "[isclient(adminC) && adminC.mob && adminC.mob.name ? stripTextMacros(adminC.mob.name) : "N/A"]")
+		var/msg = (expired ? "[row["ckey"]]'s ban removed." : "deleted [row["ckey"]]'s ban.")
+		discord_send("[name] ([key]) [msg]", -1)
 
 		return 0
 
@@ -892,4 +888,3 @@ var/global/list/playersSeen = list()
 		centralConn = 1
 		centralConnTries = 0
 		return "Set centralConn ON"
-

--- a/code/modules/admin/spacebee_extension/commands.dm
+++ b/code/modules/admin/spacebee_extension/commands.dm
@@ -47,6 +47,7 @@
 		var/ircmsg[] = new()
 		ircmsg["name"] = user
 		ircmsg["msg"] = "Added a note for [ckey]: [note]"
+		// Terra's Note: Not changing because this whole system will be stripped out.
 		ircbot.export("admin", ircmsg)
 
 /datum/spacebee_extension_command/announce
@@ -245,6 +246,7 @@
 		ircmsg["key"] = "Loggo"
 		ircmsg["name"] = "Lazy Admin Logs"
 		ircmsg["msg"] = "Logs for this round can be found here: [config.weblog_viewer_url]/ss13/admin/log-get.php?id=[config.server_id]&date=[roundLog_date]"
+		// Terra's Note: Not changing because this whole system will be stripped out.
 		ircbot.export("help", ircmsg)
 
 /datum/spacebee_extension_command/state_based/confirmation/mob_targeting/rename

--- a/code/modules/admin/spacebee_extension/system.dm
+++ b/code/modules/admin/spacebee_extension/system.dm
@@ -41,6 +41,7 @@ var/global/datum/spacebee_extension_system/spacebee_extension_system = new
 	if(config.env == "dev")
 		message_admins("Spacebee command reply to [user]: [replacetext(msg, "\n", "<br>")]")
 		return 1
+	// Terra's Note: Not changing because this whole system will be stripped out.
 	return ircbot.export("admin", list("msg" = msg))
 
 /// processes and runs a string that's supposed to be a command (with arguments and such)

--- a/code/modules/networks/computer3/comm_dish.dm
+++ b/code/modules/networks/computer3/comm_dish.dm
@@ -82,9 +82,7 @@
 		transmit_to_centcom(var/title, var/message, var/user)
 			command_alert(message, title, override_big_title="Transmission to Central Command")
 			message_admins("[user ? user : "Someone"] sent a message to Central Command:<br>[title]<br><br>[message]")
-			var/ircmsg[] = new()
-			ircmsg["msg"] = "[user ? user : "Unknown"] sent a message to Central Command:\n**[title]**\n[message]"
-			ircbot.export("admin", ircmsg)
+			discord_send("[user ? user : "Unknown"] sent a message to Central Command:\n**[title]**\n[message]", -1)
 
 		add_cargo_logs(var/atom/A)
 			if (!A)

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -30,7 +30,7 @@ datum/shuttle_controller
 			settimeleft(SHUTTLEARRIVETIME)
 			online = 1
 
-		discord_send("Shuttled called on [config.server_name] with [src.timeleft()] seconds until arrival.", "event")
+		discord_send("Shuttle called on [config.server_name] with [src.timeleft()] seconds until arrival.", "event")
 
 	proc/recall()
 		if (online && direction == 1)

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -30,13 +30,13 @@ datum/shuttle_controller
 			settimeleft(SHUTTLEARRIVETIME)
 			online = 1
 
-		INVOKE_ASYNC(ircbot, /datum/ircbot.proc/event, "shuttlecall", src.timeleft())
+		discord_send("Shuttled called on [config.server_name] with [src.timeleft()] seconds until arrival.", "event")
 
 	proc/recall()
 		if (online && direction == 1)
 			world << csound("sound/misc/shuttle_recalled.ogg")
 			setdirection(-1)
-			ircbot.event("shuttlerecall", src.timeleft())
+			discord_send("Shuttle recalled on [config.server_name] with [src.timeleft()] seconds until arrival at CentCom.", "event")
 
 	proc/get_location()
 		switch(location)
@@ -182,7 +182,7 @@ datum/shuttle_controller
 								S.establish_bridge()
 
 						boutput(world, "<B>The Emergency Shuttle has docked with the station! You have [timeleft()/60] minutes to board the Emergency Shuttle.</B>")
-						ircbot.event("shuttledock")
+						discord_send("Shuttle docked with station on [config.server_name].", "event")
 						world << csound("sound/misc/shuttle_arrive1.ogg")
 
 						processScheduler.enableProcess("Fluid_Turfs")

--- a/code/procs/computer_id.dm
+++ b/code/procs/computer_id.dm
@@ -76,9 +76,6 @@ proc/check_compid_list(var/client/C)
 						//If the ID changed within 3 hours and the ID hasn't been seen several times (unlikely to happen with automatically generated IDs
 						hits++
 			if(hits)
-				var/ircmsg[] = new()
-				ircmsg["key"] =  C.key
-				ircmsg["name"] = stripTextMacros(C.mob.real_name)
 				var/msg = "'s compID changed [hits] time[hits>1 ? "s" : null] within the last 180 minutes - [C.compid_info_list.len + 1] IDs on file."
 				if(hits >= 2) //This person used 3 computers within as many hours
 					if(!cid_test) cid_test = list()
@@ -96,8 +93,7 @@ proc/check_compid_list(var/client/C)
 					message_admins("[key_name(C)][msg]")
 					logTheThing("admin", C, null, "[key_name(C)][msg]")
 
-				ircmsg["msg"] = "(IP: [C.address]) [msg]"
-				ircbot.export("admin", ircmsg)
+				discord_send("[stripTextMacros(C.mob.real_name)] ([C.key]) (IP: [C.address]) [msg]", -1)
 
 
 		//Done with the analysis
@@ -122,11 +118,7 @@ proc/do_computerid_test(var/client/C)
 
 	var/msg = " [is_fucker ? "failed" : "passed"] the automatic cid dll test."
 
-	var/ircmsg[] = new()
-	ircmsg["key"] =  C.key
-	ircmsg["name"] = stripTextMacros(C.mob.real_name)
-	ircmsg["msg"] = " [msg]"
-	ircbot.export("admin", ircmsg)
+	discord_send("[stripTextMacros(C.mob.real_name)] ([C.key]) [msg]", -1)
 	message_admins("[key_name(C)][msg]")
 	logTheThing("admin", C, null, msg)
 	if(is_fucker)

--- a/code/procs/station_name.dm
+++ b/code/procs/station_name.dm
@@ -197,11 +197,9 @@ var/global/lastStationNameChange = 0 //timestamp
 			logTheThing("diary", user, null, "changed the station name to: [name]", "admin")
 			message_admins("[key_name(user)] changed the station name to: [name]")
 
-			var/ircmsg[] = new()
-			ircmsg["key"] = user.client.key
-			ircmsg["name"] = (user?.real_name) ? stripTextMacros(user.real_name) : "NULL"
-			ircmsg["msg"] = "changed the station name to [name]"
-			ircbot.export("admin", ircmsg)
+			var/key = user.client.key
+			var/realname = (user?.real_name) ? stripTextMacros(user.real_name) : "NULL"
+			discord_send("[realname] ([key]) changed the station name to [name]", -1)
 
 	else
 		name = generate_random_station_name()

--- a/code/world.dm
+++ b/code/world.dm
@@ -1607,7 +1607,7 @@ var/f_color_selector_handler/F_Color_Selector
 					ircmsg["msg"] = "Removed the restart delay."
 
 					SPAWN_DBG(1 DECI SECOND)
-						discord_send("Round just ended on [config.server_name].", "status")
+						discord_send("Round just ended on [config.server_name].", -1)
 						Reboot_server()
 
 					return ircbot.response(ircmsg)

--- a/code/world.dm
+++ b/code/world.dm
@@ -542,7 +542,7 @@ var/f_color_selector_handler/F_Color_Selector
 	SetupOccupationsList()
 
 	Z_LOG_DEBUG("World/Init", "Notifying Discord of new round")
-	ircbot.event("serverstart", list("map" = getMapNameFromID(map_setting), "gamemode" = (ticker?.hide_mode) ? "secret" : master_mode))
+	discord_send("New round starting on [config.server_name] with map [getMapNameFromID(map_setting)] and gamemode [(ticker?.hide_mode) ? "secret" : master_mode]!", "status")
 	world.log << "Map: [getMapNameFromID(map_setting)]"
 
 	Z_LOG_DEBUG("World/Init", "Notifying hub of new round")
@@ -1607,7 +1607,7 @@ var/f_color_selector_handler/F_Color_Selector
 					ircmsg["msg"] = "Removed the restart delay."
 
 					SPAWN_DBG(1 DECI SECOND)
-						ircbot.event("roundend")
+						discord_send("Round just ended on [config.server_name].", "status")
 						Reboot_server()
 
 					return ircbot.response(ircmsg)


### PR DESCRIPTION
Adds some bare-bones TGS commands, like check, ping and a reboot command
refactors all the discord send code to transmit to some TGS channels.

Channels are tagged with the following to split up messages:
* event - round event info, shuttle calls etc for admins only
* ahelp - high priority admin messages like ahelps **this channel should be set to receive admin messages in TGS, in addition to the tag**
* status - channel to send server status messages to. round starting etc **this channel should be set to receive watchdog messages in TGS in addition to the tag**
* In addition to these specific channels, any channels where you want TGS commands to be usable should be added without any specific roles (they can have any tag to identify them) TGS admin commands can only be used in the channel tagged for tgs admin messages.